### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Lint
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/thinkgos/timer/security/code-scanning/1](https://github.com/thinkgos/timer/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the least privilege required. Since the workflow only runs linters and does not need to write to the repository or interact with issues or pull requests, the minimal required permission is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to set it at the workflow level unless a job needs different permissions. To implement the fix, add the following block after the `name:` line and before the `on:` block in `.github/workflows/lint.yml`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
