### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/thinkgos/timer/security/code-scanning/3](https://github.com/thinkgos/timer/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the least privilege required. Since the workflow only checks out code, runs tests, and uploads coverage (with no evidence of needing write access to the repository), the minimal permission of `contents: read` is sufficient. This can be set at the workflow level (top-level, after `name:` and before `on:`) to apply to all jobs, or at the job level if only specific jobs need it. The best practice is to set it at the workflow level unless a job requires different permissions.  
**Change:**  
- Insert the following block after the `name: Tests` line (line 1):  
  ```yaml
  permissions:
    contents: read
  ```
No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
