### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_review_dog.yml
+++ b/.github/workflows/pr_review_dog.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Reviewdog
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/thinkgos/timer/security/code-scanning/2](https://github.com/thinkgos/timer/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions. The minimal starting point recommended by CodeQL is `contents: read`, which allows the workflow to read repository contents but not write to them. This block can be added either at the root of the workflow (to apply to all jobs) or at the job level (to apply only to specific jobs). In this case, since there is only one job, adding it at the root is simplest and most effective. You should insert the following block after the `name:` line and before the `on:` block in `.github/workflows/pr_review_dog.yml`:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
